### PR TITLE
Move answers to answers table

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,3 +1,3 @@
 class Question < ApplicationRecord
-  validates :category, :question, :answer, :points, presence: true
+  validates :category, :question, :points, presence: true
 end

--- a/db/migrate/20160817034645_remove_answersfrom_questions.rb
+++ b/db/migrate/20160817034645_remove_answersfrom_questions.rb
@@ -1,0 +1,5 @@
+class RemoveAnswersfromQuestions < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :questions, :answer, :string
+  end
+end

--- a/db/migrate/20160817040205_create_answers.rb
+++ b/db/migrate/20160817040205_create_answers.rb
@@ -1,0 +1,10 @@
+class CreateAnswers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :answers do |t|
+      t.string :answer
+      t.boolean :correct?, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160812171325) do
+ActiveRecord::Schema.define(version: 20160817034645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,6 @@ ActiveRecord::Schema.define(version: 20160812171325) do
   create_table "questions", force: :cascade do |t|
     t.string   "category"
     t.string   "question"
-    t.string   "answer"
     t.integer  "points"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160817034645) do
+ActiveRecord::Schema.define(version: 20160817040205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "answers", force: :cascade do |t|
+    t.string   "answer"
+    t.boolean  "correct?",   default: false, null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
 
   create_table "questions", force: :cascade do |t|
     t.string   "category"

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class QuestionTest < ActiveSupport::TestCase
   def setup 
-    @question = Question.new(category: "history", question: "In what year did World War 2 End?", answer: "1945", points: 1)
+    @question = Question.new(category: "history", question: "In what year did World War 2 End?", points: 1)
   end
 
   test "valid question" do
@@ -16,11 +16,6 @@ class QuestionTest < ActiveSupport::TestCase
 
   test "empty questions are invalid" do
     @question.question = nil
-    assert_not @question.valid?
-  end
-
-  test "questions without an answer are invalid" do
-    @question.answer = nil
     assert_not @question.valid?
   end
 


### PR DESCRIPTION
- Removed the 'answers' field from the 'Questions' table
- Created a new 'Answers' table migration
